### PR TITLE
Fix monitoring cannot start error

### DIFF
--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -24,6 +24,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-hystrix-dashboard</artifactId>
 		</dependency>
+                <dependency>
+                        <groupId>org.springframework.cloud</groupId>
+                        <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
Add eureka client dependency to monitor.