### PR TITLE
add spring-boot-test dependency to fix packaging failure

### DIFF
--- a/account-service/pom.xml
+++ b/account-service/pom.xml
@@ -100,8 +100,13 @@
 			<artifactId>json-path</artifactId>
 			<version>2.2.0</version>
 			<scope>test</scope>
-		</dependency>
-	</dependencies>
+		</dependency>	
+   <dependency>
+     <groupId>org.springframework.boot</groupId>
+     <artifactId>spring-boot-test</artifactId>
+     <version>2.1.7.RELEASE</version>
+   </dependency>
+ </dependencies>
 	
 	<build>
 		<plugins>


### PR DESCRIPTION
Running `mvn clean package -DskipTests` resulted in the following error

```
[INFO] auth-service 1.0-SNAPSHOT .......................... SUCCESS [  2.042 s]
[INFO] account-service 1.0-SNAPSHOT ....................... FAILURE [  1.687 s]
[INFO] statistics-service 1.0-SNAPSHOT .................... SKIPPED
[INFO] notification-service 1.0.0-SNAPSHOT ................ SKIPPED
[INFO] turbine-stream-service 0.0.1-SNAPSHOT .............. SKIPPED

...

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project account-service: Compilation failure: Compilation failure: 
[ERROR] /Users/myho/dev/work/learning/spring/piggymetrics/account-service/src/test/java/com/piggymetrics/account
```